### PR TITLE
Remove resource for azurerm_resource_group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,10 +7,8 @@ module "os" {
   vm_os_simple = var.vm_os_simple
 }
 
-resource "azurerm_resource_group" "vm" {
-  name     = var.resource_group_name
-  location = var.location
-  tags     = var.tags
+data "azurerm_resource_group" "vm" {
+  name = var.resource_group_name
 }
 
 resource "random_id" "vm-sa" {
@@ -24,7 +22,7 @@ resource "random_id" "vm-sa" {
 resource "azurerm_storage_account" "vm-sa" {
   count                    = var.boot_diagnostics ? 1 : 0
   name                     = "bootdiag${lower(random_id.vm-sa.hex)}"
-  resource_group_name      = azurerm_resource_group.vm.name
+  resource_group_name      = var.resource_group_name
   location                 = var.location
   account_tier             = element(split("_", var.boot_diagnostics_sa_type), 0)
   account_replication_type = element(split("_", var.boot_diagnostics_sa_type), 1)
@@ -35,7 +33,7 @@ resource "azurerm_virtual_machine" "vm-linux" {
   count                         = ! contains(list(var.vm_os_simple, var.vm_os_offer), "Windows") && ! var.is_windows_image && ! var.data_disk ? var.nb_instances : 0
   name                          = "${var.vm_hostname}${count.index}"
   location                      = var.location
-  resource_group_name           = azurerm_resource_group.vm.name
+  resource_group_name           = var.resource_group_name
   availability_set_id           = var.availability_set_id != "" ? var.availability_set_id : azurerm_availability_set.vm.id
   vm_size                       = var.vm_size
   network_interface_ids         = [element(azurerm_network_interface.vm.*.id, count.index)]
@@ -85,7 +83,7 @@ resource "azurerm_virtual_machine" "vm-linux-with-datadisk" {
   count                         = ! contains(list(var.vm_os_simple, var.vm_os_offer), "Windows") && ! var.is_windows_image && var.data_disk ? var.nb_instances : 0
   name                          = "${var.vm_hostname}${count.index}"
   location                      = var.location
-  resource_group_name           = azurerm_resource_group.vm.name
+  resource_group_name           = var.resource_group_name
   availability_set_id           = var.availability_set_id != "" ? var.availability_set_id : azurerm_availability_set.vm.id
   vm_size                       = var.vm_size
   network_interface_ids         = [element(azurerm_network_interface.vm.*.id, count.index)]
@@ -143,7 +141,7 @@ resource "azurerm_virtual_machine" "vm-windows" {
   count                         = ((var.is_windows_image || contains(list(var.vm_os_simple, var.vm_os_offer), "Windows")) && ! var.data_disk) ? var.nb_instances : 0
   name                          = "${var.vm_hostname}${count.index}"
   location                      = var.location
-  resource_group_name           = azurerm_resource_group.vm.name
+  resource_group_name           = var.resource_group_name
   availability_set_id           = var.availability_set_id != "" ? var.availability_set_id : azurerm_availability_set.vm.id
   vm_size                       = var.vm_size
   network_interface_ids         = [element(azurerm_network_interface.vm.*.id, count.index)]
@@ -187,7 +185,7 @@ resource "azurerm_virtual_machine" "vm-windows-with-datadisk" {
   count                         = (var.is_windows_image || contains(list(var.vm_os_simple, var.vm_os_offer), "Windows")) && var.data_disk ? var.nb_instances : 0
   name                          = "${var.vm_hostname}${count.index}"
   location                      = var.location
-  resource_group_name           = azurerm_resource_group.vm.name
+  resource_group_name           = var.resource_group_name
   availability_set_id           = var.availability_set_id != "" ? var.availability_set_id : azurerm_availability_set.vm.id
   vm_size                       = var.vm_size
   network_interface_ids         = [element(azurerm_network_interface.vm.*.id, count.index)]
@@ -237,8 +235,8 @@ resource "azurerm_virtual_machine" "vm-windows-with-datadisk" {
 
 resource "azurerm_availability_set" "vm" {
   name                         = "${var.vm_hostname}-avset"
-  location                     = azurerm_resource_group.vm.location
-  resource_group_name          = azurerm_resource_group.vm.name
+  location                     = data.azurerm_resource_group.vm.location
+  resource_group_name          = var.resource_group_name
   platform_fault_domain_count  = 2
   platform_update_domain_count = 2
   managed                      = true
@@ -249,7 +247,7 @@ resource "azurerm_public_ip" "vm" {
   count               = var.nb_public_ip
   name                = "${var.vm_hostname}-${count.index}-publicIP"
   location            = var.location
-  resource_group_name = azurerm_resource_group.vm.name
+  resource_group_name = var.resource_group_name
   allocation_method   = coalesce(var.allocation_method, var.public_ip_address_allocation, "Dynamic")
   domain_name_label   = element(var.public_ip_dns, count.index)
   tags                = var.tags
@@ -257,8 +255,8 @@ resource "azurerm_public_ip" "vm" {
 
 resource "azurerm_network_security_group" "vm" {
   name                = "${var.vm_hostname}-${coalesce(var.remote_port, module.os.calculated_remote_port)}-nsg"
-  location            = azurerm_resource_group.vm.location
-  resource_group_name = azurerm_resource_group.vm.name
+  location            = data.azurerm_resource_group.vm.location
+  resource_group_name = var.resource_group_name
 
   tags = var.tags
 }
@@ -274,15 +272,15 @@ resource "azurerm_network_security_rule" "vm" {
   destination_port_range      = coalesce(var.remote_port, module.os.calculated_remote_port)
   source_address_prefix       = "*"
   destination_address_prefix  = "*"
-  resource_group_name         = azurerm_resource_group.vm.name
+  resource_group_name         = var.resource_group_name
   network_security_group_name = azurerm_network_security_group.vm.name
 }
 
 resource "azurerm_network_interface" "vm" {
   count                         = var.nb_instances
   name                          = "nic-${var.vm_hostname}-${count.index}"
-  location                      = azurerm_resource_group.vm.location
-  resource_group_name           = azurerm_resource_group.vm.name
+  location                      = data.azurerm_resource_group.vm.location
+  resource_group_name           = var.resource_group_name
   network_security_group_id     = azurerm_network_security_group.vm.id
   enable_accelerated_networking = var.enable_accelerated_networking
 

--- a/main.tf
+++ b/main.tf
@@ -7,10 +7,6 @@ module "os" {
   vm_os_simple = var.vm_os_simple
 }
 
-data "azurerm_resource_group" "vm" {
-  name = var.resource_group_name
-}
-
 resource "random_id" "vm-sa" {
   keepers = {
     vm_hostname = var.vm_hostname
@@ -235,7 +231,7 @@ resource "azurerm_virtual_machine" "vm-windows-with-datadisk" {
 
 resource "azurerm_availability_set" "vm" {
   name                         = "${var.vm_hostname}-avset"
-  location                     = data.azurerm_resource_group.vm.location
+  location                     = var.location
   resource_group_name          = var.resource_group_name
   platform_fault_domain_count  = 2
   platform_update_domain_count = 2
@@ -255,7 +251,7 @@ resource "azurerm_public_ip" "vm" {
 
 resource "azurerm_network_security_group" "vm" {
   name                = "${var.vm_hostname}-${coalesce(var.remote_port, module.os.calculated_remote_port)}-nsg"
-  location            = data.azurerm_resource_group.vm.location
+  location            = var.location
   resource_group_name = var.resource_group_name
 
   tags = var.tags
@@ -279,7 +275,7 @@ resource "azurerm_network_security_rule" "vm" {
 resource "azurerm_network_interface" "vm" {
   count                         = var.nb_instances
   name                          = "nic-${var.vm_hostname}-${count.index}"
-  location                      = data.azurerm_resource_group.vm.location
+  location                      = var.location
   resource_group_name           = var.resource_group_name
   network_security_group_id     = azurerm_network_security_group.vm.id
   enable_accelerated_networking = var.enable_accelerated_networking


### PR DESCRIPTION
# Background
All resources of Azure resource group will be destroyed in the destroying one module. (like cassandra module)

# Workaround
Removed for creating `azurermre_source_group`, Because the resource group was created by network module.
https://github.com/scalar-labs/scalar-terraform/blob/master/modules/azure/network/main.tf#L7