### PR TITLE
Add SystemAssigned identity to azurerm_virtual_machine

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -73,6 +73,10 @@ resource "azurerm_virtual_machine" "vm-linux" {
     enabled     = var.boot_diagnostics
     storage_uri = var.boot_diagnostics ? join(",", azurerm_storage_account.vm-sa.*.primary_blob_endpoint) : ""
   }
+
+  identity {
+    type = "SystemAssigned"
+  }
 }
 
 resource "azurerm_virtual_machine" "vm-linux-with-datadisk" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,11 @@ output "vm_ids" {
   value       = "${concat(azurerm_virtual_machine.vm-windows.*.id, azurerm_virtual_machine.vm-windows-with-datadisk.*.id, azurerm_virtual_machine.vm-linux.*.id, azurerm_virtual_machine.vm-linux-with-datadisk.*.id)}"
 }
 
+output "vm_identities" {
+  description = "identities of virtual machines created."
+  value       = "${concat(azurerm_virtual_machine.vm-windows.*.identity, azurerm_virtual_machine.vm-windows-with-datadisk.*.identity, azurerm_virtual_machine.vm-linux.*.identity, azurerm_virtual_machine.vm-linux-with-datadisk.*.identity)}"
+}
+
 output "network_security_group_id" {
   description = "id of the security group provisioned"
   value       = "${azurerm_network_security_group.vm.id}"


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-5554
https://scalar-labs.atlassian.net/browse/DLT-5885

Adds an `identity` block to the virtual machine that assigns `SystemAssigned` identity type.

https://www.terraform.io/docs/providers/azurerm/guides/managed_service_identity.html#configuring-a-vm-to-use-a-system-assigned-managed-identity
